### PR TITLE
Allow backups for multiple tables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
    $ sls install --url https://github.com/alexdebrie/serverless-dynamodb-backups && cd serverless-dynamodb-backups
    ```
    
-3. Update the `tableName`, `slackWebhook`, `awsRegion`, and `backupRate` in the `custom` block of `serverless.yml`. See [Configuration](#configuration) for more details.
+3. Update the required [configuration](#configuration) in the `custom` block of `serverless.yml`.
 
 4. Deploy!
 
@@ -24,11 +24,17 @@
 
 # Configuration
 
-There are three things to configure in the `custom` block of `serverless.yml`:
+There are three ways you can specify which tables to backup:
 
-- `tableName` - **required** - The name of the DynamoDB table you want to backup
+1. **Regex on all tables in region.** The function can call the `ListTables` API and include all tables whose name matches a given regular expression. This is the most dynamic configuration, as you won't need to redeploy this function every time you add a new DynamoDB table. This works best if you have a specified naming scheme for your tables, such as prefixing all tables with the stage. Then you can add a pattern of `"^(prod-)."` to match all tables that start with `prod-`. To use this method, put your regular expression in the `tableRegex` property. 
+
+2. **Specify multiple table names in an included file.** If you have a list of tables you want to back up, you can place their names in a local file and specify the name of the file in the `tableFile` property. The format must be valid JSON that is a list of strings. A `tables.json` file is included in this repo as an example.
+
+3. **Specify a single table via environment variable.** If you only have one table to backup, you can specify its name via the `tableName` property.
+
+In addition to the table configuration, there is also the following configuration:
+
 - `backupRate` - **required** - The schedule on which you want to backup your table. You can use either `rate` syntax (`rate(1 hour)`) or `cron` syntax (`cron(0 12 * * ? *)`). See [here](https://serverless.com/framework/docs/providers/aws/events/schedule/) for more details on configuration.
-- `awsRegion` - **required** - The AWS Region where you'll deploy your service. This should be the same region as your DynamoDB table.
 - `slackWebhook` - **optional** - An HTTPS endpoint for an [incoming webhook](https://api.slack.com/incoming-webhooks) to Slack. If provided, it will send success + error messages to a Slack channel when it runs.
 
 # Notes
@@ -38,6 +44,5 @@ There are three things to configure in the `custom` block of `serverless.yml`:
 
 # Potential improvements
 
-- **Multiple tables?** Currently you would need to deploy a separate service for each table you want to back up. A future solution have a file that lists all tables to be backed up.
 - **Better control on notifications?** We could implement email or SMS messages, as well as the ability to only notify on failures.
 - **Cleanup of old backups?** It could be nice to delete all backups older than X days to avoid being charged for backup storage.

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,15 +1,15 @@
 service: serverless-dynamodb-backups
 
 custom:
-  tableName: "SET-MY-TABLE-NAME"
+  tableRegex: "" # Set if you want to use a Regex pattern against all tables in region.
+  tableFile: "" # Set if you want to read table names from a file.
+  tableName: "" # Set if you want to backup a single table
   backupRate: rate(10 minutes)
-  awsRegion: "CHANGE-ME"
   slackWebhook: ""
 
 provider:
   name: aws
   runtime: python3.6
-  region: ${self:custom.awsRegion}
   timeout: 30
   memorySize: 128
   iamRoleStatements:
@@ -22,13 +22,19 @@ provider:
           - - "arn:aws:dynamodb"
             - Ref: 'AWS::Region'
             - Ref: 'AWS::AccountId'
-            - "table/${self:custom.tableName}"
+            - "table/*"
+    - Effect: "Allow"
+      Action:
+        - "dynamodb:ListTables"
+      Resource: "*"
   environment:
+    TABLE_REGEX: ${self:custom.tableRegex}
+    TABLE_FILE: ${self:custom.tableFile}
     TABLE_NAME: ${self:custom.tableName}
     SLACK_WEBHOOK: ${self:custom.slackWebhook}
 
 functions:
   createBackup:
-    handler: handler.create_backup
+    handler: handler.main
     events:
       - schedule: ${self:custom.backupRate}

--- a/tables.json
+++ b/tables.json
@@ -1,0 +1,1 @@
+["test-table-1", "test-table-2"]


### PR DESCRIPTION
Closes #1.

This adds a few new configuration methods to allow for backing up multiple tables in a single function 💥 : 

- **Regex pattern.** Users can specify a regex pattern that will be evaluated against all tables in the region. Any table that matches the pattern will be backed up.

- **File listing.** Users can include a file with the names of tables to be backed up. 