### PR TITLE
Update python version to 3.13

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,7 @@ custom:
 
 provider:
   name: aws
-  runtime: python3.6
+  runtime: python3.13
   timeout: 30
   memorySize: 128
   iamRoleStatements:


### PR DESCRIPTION
Serverless doesn't support 3.6 anymore. Updating to python 3.13.